### PR TITLE
Fix combat health bar tracking

### DIFF
--- a/src/combat.js
+++ b/src/combat.js
@@ -15,6 +15,8 @@ export class CombatSystem {
     if(tipo==='minion') enemigo = JSON.parse(JSON.stringify(isla.enemigos[enemigoIdx]));
     else enemigo = JSON.parse(JSON.stringify(isla.monstruo));
     this.enemigo = enemigo;
+    // Guardar la salud inicial para calcular correctamente la barra de vida
+    this.enemigo.saludInicial = enemigo.salud;
     this.monstruoFinal = (tipo==='monstruo');
     this.renderCombate();
   }
@@ -45,7 +47,9 @@ export class CombatSystem {
   }
   updateBarras() {
     let pctJ = Math.max(0, Math.min(1, this.data.player.salud/this.data.player.saludMax));
-    let pctE = Math.max(0, Math.min(1, this.enemigo.salud/(this.monstruoFinal?this.enemigo.salud+this.data.player.arma.daño:this.enemigo.salud+this.data.player.arma.daño)));
+    // Calcular porcentaje de vida del enemigo usando su salud inicial
+    const maxSaludEnemigo = this.enemigo.saludInicial || this.enemigo.salud;
+    let pctE = Math.max(0, Math.min(1, this.enemigo.salud / maxSaludEnemigo));
     document.getElementById('barraVidaJugador').style.width = (pctJ*100)+'%';
     document.getElementById('barraVidaEnemigo').style.width = (pctE*100)+'%';
   }


### PR DESCRIPTION
## Summary
- store enemy initial health when combat starts
- fix enemy health bar percentage calculation

## Testing
- `node --check src/combat.js`

------
https://chatgpt.com/codex/tasks/task_e_68426ef452f4832db0f9e9aba27ca69e