### PR TITLE
Add combat equivalence tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Factorilandia
+
+## Running Tests
+
+Install Node.js (version 18 or higher). Then run:
+
+```bash
+npm test
+```
+
+This uses Node's built-in test runner to execute files in the `tests` directory.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "factorilandia",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/tests/combat.test.js
+++ b/tests/combat.test.js
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { CombatSystem } from '../src/combat.js';
+
+// Stub minimal DOM for constructor
+global.document = {
+  getElementById: () => ({ style: {}, innerHTML: '' })
+};
+
+const cs = new CombatSystem({}, {}, {});
+
+test('direct equality', () => {
+  assert.ok(cs.respuestasEquivalentes('x^2+3x+2', 'x^2+3x+2'));
+});
+
+test('ignore spaces and plus signs', () => {
+  assert.ok(cs.respuestasEquivalentes('x^2 + 3x + 2', 'x^2+3x+2'));
+  assert.ok(cs.respuestasEquivalentes('x^2+3x+2', 'x^2 3x 2'));
+});
+
+test('commutative factor pairs', () => {
+  assert.ok(cs.respuestasEquivalentes('(x+a)(x-b)', '(x-b)(x+a)'));
+  assert.ok(!cs.respuestasEquivalentes('(x+a)(x-b)', '(x+a)(x+b)'));
+});


### PR DESCRIPTION
## Summary
- add a simple test suite for `respuestasEquivalentes`
- provide an npm script using Node's built-in test runner
- document how to run the tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68427099e7a4832d862679c0dcdf7a7c