### PR TITLE
Improve aspas instructions and completion message

### DIFF
--- a/src/combat3d.js
+++ b/src/combat3d.js
@@ -802,6 +802,15 @@ export class Combat3D {
         const c = parseInt(match[2]);
         this.pistasList.push(`Busca dos números que multiplicados den -${c} y sumados den ${b}.`);
       }
+    } else if (expresion.match(/\d+x\^2/)) {
+      // Trinomio general ax^2 + bx + c con a diferente de 1
+      const match = expresion.match(/(\d+)x\^2\s*([+-])\s*(\d+)x\s*([+-])\s*(\d+)/);
+      if (match) {
+        const a = parseInt(match[1]);
+        const b = parseInt(match[3]) * (match[2] === '-' ? -1 : 1);
+        const c = parseInt(match[5]) * (match[4] === '-' ? -1 : 1);
+        this.pistasList.push(`Busca dos números que multiplicados den ${a*c} y sumados den ${b}.`);
+      }
     } else if (expresion.includes('(x+3)^2')) {
       this.pistasList.push("Desarrolla la expresión (x+3)² = (x+3)(x+3).");
     }

--- a/src/data.js
+++ b/src/data.js
@@ -37,12 +37,12 @@ export class GameData {
             salud: 70,
             color: "#9e9d24",
             ejercicios: [
-              {pregunta: "¿Factoriza: x^3 + 3x^2 + 2x + 6?", respuesta: "(x^2+2)(x+3)"},
-              {pregunta: "¿Factoriza: 2x^3 + 4x^2 + 3x + 6?", respuesta: "(2x^2+3)(x+2)"},
-              {pregunta: "¿Factoriza: a^3 + 2a^2 + 5a + 10?", respuesta: "(a^2+5)(a+2)"}
+              {pregunta: "¿Factoriza: 2x^2 + 7x + 3?", respuesta: "(2x+1)(x+3)"},
+              {pregunta: "¿Factoriza: 3x^2 + 8x + 4?", respuesta: "(3x+2)(x+2)"},
+              {pregunta: "¿Factoriza: 6a^2 + 11a + 3?", respuesta: "(3a+1)(2a+3)"}
             ],
-            pregunta: "¿Factoriza: x^3 + 3x^2 + 2x + 6?",
-            respuesta: "(x^2+2)(x+3)"
+            pregunta: "¿Factoriza: 2x^2 + 7x + 3?",
+            respuesta: "(2x+1)(x+3)"
           },
           {
             nombre: "Monstruo TCP",
@@ -130,7 +130,7 @@ export class GameData {
       },
       {
         titulo: "Factorización por aspas",
-        contenido: "Agrupar términos de dos en dos y extraer factor común. Ejemplo: x³ + 3x² + 2x + 6 = (x² + 2)(x + 3)"
+        contenido: "Para un trinomio ax^2+bx+c, busca dos números que multiplicados den a·c y sumados den b. Ejemplo: 2x²+7x+3 = (2x+1)(x+3)"
       },
       {
         titulo: "Trinomio cuadrado perfecto",

--- a/src/overworld.js
+++ b/src/overworld.js
@@ -442,6 +442,8 @@ export class OverworldMap {
       this.reproducirSonido('cambioIsla');
       
       console.log(`Cambio a isla ${nuevaIsla} completado`);
+    } else if (nuevaIsla >= this.data.islas.length && this.data.esIslaCompletada(this.islaActual)) {
+      this.hud.showMessage('¡Lo lograste! Felicidades por completar Factorilandia.');
     }
   }
   


### PR DESCRIPTION
## Summary
- fix Bestia de las Aspas to use trinomial examples
- clarify parchment explanation of factoring by aspas
- add hint generation for generic `ax^2+bx+c` expressions
- show a congratulatory message when all islands are completed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d99e35694832db44bc30508d1dcad