### PR TITLE
feat: add general trinomial island

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -93,6 +93,61 @@ export class GameData {
           pregunta: "¿Factoriza: 8m^2 - 12m?",
           respuesta: "4m(2m-3)"
         }
+      },
+      {
+        nombre: "Isla ax²+bx+c",
+        tema: "Trinomios generales",
+        color: "#F0A0D8",
+        descripcion: "En esta isla aprenderás a factorizar trinomios con coeficiente principal distinto de 1.",
+        enemigos: [
+          {
+            nombre: "Bandido Ax²",
+            salud: 70,
+            color: "#ab47bc",
+            ejercicios: [
+              {pregunta: "¿Factoriza: 2x^2 + 5x + 3?", respuesta: "(2x+3)(x+1)"},
+              {pregunta: "¿Factoriza: 3x^2 + 10x + 7?", respuesta: "(3x+7)(x+1)"},
+              {pregunta: "¿Factoriza: 4a^2 + 11a + 6?", respuesta: "(4a+3)(a+2)"}
+            ],
+            pregunta: "¿Factoriza: 2x^2 + 5x + 3?",
+            respuesta: "(2x+3)(x+1)"
+          },
+          {
+            nombre: "Asaltante Bx",
+            salud: 80,
+            color: "#ff7043",
+            ejercicios: [
+              {pregunta: "¿Factoriza: 5x^2 + 13x + 6?", respuesta: "(5x+3)(x+2)"},
+              {pregunta: "¿Factoriza: 6m^2 + 7m - 3?", respuesta: "(3m-1)(2m+3)"},
+              {pregunta: "¿Factoriza: 3y^2 - 4y - 4?", respuesta: "(3y+2)(y-2)"}
+            ],
+            pregunta: "¿Factoriza: 5x^2 + 13x + 6?",
+            respuesta: "(5x+3)(x+2)"
+          },
+          {
+            nombre: "Cazador C",
+            salud: 85,
+            color: "#26a69a",
+            ejercicios: [
+              {pregunta: "¿Factoriza: 4x^2 - x - 5?", respuesta: "(4x+5)(x-1)"},
+              {pregunta: "¿Factoriza: 7x^2 + 2x - 3?", respuesta: "(7x-3)(x+1)"},
+              {pregunta: "¿Factoriza: 3a^2 - a - 4?", respuesta: "(3a+4)(a-1)"}
+            ],
+            pregunta: "¿Factoriza: 4x^2 - x - 5?",
+            respuesta: "(4x+5)(x-1)"
+          }
+        ],
+        monstruo: {
+          nombre: "Señor ax²+bx+c",
+          salud: 130,
+          ejercicios: [
+            {pregunta: "¿Factoriza: 6x^2 + x - 2?", respuesta: "(3x+2)(2x-1)"},
+            {pregunta: "¿Factoriza: 8a^2 + 14a + 3?", respuesta: "(4a+1)(2a+3)"},
+            {pregunta: "¿Factoriza: 9m^2 - 6m - 8?", respuesta: "(3m+2)(3m-4)"}
+          ],
+          pregunta: "¿Factoriza: 6x^2 + x - 2?",
+          respuesta: "(3x+2)(2x-1)"
+        }
       }
     ];
     
@@ -111,6 +166,15 @@ export class GameData {
         {x:820, y:320, tipo:'cofre', isla:0, chestID:'chest5', parchment:4},
         {x:895, y:260, tipo:'minion', isla:0, idx:4},
         {x:970, y:320, tipo:'monstruo', isla:0},
+        // Isla 1: ax²+bx+c
+        {x:145, y:260, tipo:'profesor', isla:1},
+        {x:220, y:320, tipo:'cofre', isla:1, chestID:'chest6', parchment:0},
+        {x:295, y:260, tipo:'minion', isla:1, idx:0},
+        {x:370, y:320, tipo:'cofre', isla:1, chestID:'chest7', parchment:1},
+        {x:445, y:260, tipo:'minion', isla:1, idx:1},
+        {x:520, y:320, tipo:'cofre', isla:1, chestID:'chest8', parchment:2},
+        {x:595, y:260, tipo:'minion', isla:1, idx:2},
+        {x:670, y:320, tipo:'monstruo', isla:1},
       ];
     
     // Rutas alternativas o atajos (para expansión futura)

--- a/tests/isla.test.js
+++ b/tests/isla.test.js
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { GameData } from '../src/data.js';
+
+test('GameData incluye isla ax²+bx+c', () => {
+  const data = new GameData();
+  const isla = data.islas.find(i => i.nombre.includes('ax²+bx+c'));
+  assert.ok(isla, 'Debe existir la isla ax²+bx+c');
+  assert.equal(isla.enemigos.length, 3);
+});
+
+test('mapNodos contiene nodos para la nueva isla', () => {
+  const data = new GameData();
+  const nodos = data.mapNodos.filter(n => n.isla === 1);
+  assert.ok(nodos.length > 0, 'Deben existir nodos para la isla 1');
+});


### PR DESCRIPTION
## Summary
- add `Isla ax²+bx+c` with enemies and boss for general trinomials
- map nodes extended for the new island
- test coverage for island presence

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ad32bc0bc832d88b0fccceb86c540