### PR TITLE
Make overworld responsive and show final boss overlay

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -66,19 +66,28 @@ export class Game {
             this.data.player.exp += tipo === 'monstruo' ? 50 : 25;
             this.data.player.monedas += tipo === 'monstruo' ? 40 : 20;
 
-            if (tipo === 'minion') {
-              if (!this.data.enemigosDerrotados.minions.some(e => e.isla === islaIdx && e.idx === enemigoIdx)) {
-                this.data.enemigosDerrotados.minions.push({isla: islaIdx, idx: enemigoIdx});
-                console.log('Minion derrotado y registrado:', islaIdx, enemigoIdx);
-                console.log('Estado actual:', JSON.stringify(this.data.enemigosDerrotados));
+              if (tipo === 'minion') {
+                if (!this.data.enemigosDerrotados.minions.some(e => e.isla === islaIdx && e.idx === enemigoIdx)) {
+                  this.data.enemigosDerrotados.minions.push({isla: islaIdx, idx: enemigoIdx});
+                  console.log('Minion derrotado y registrado:', islaIdx, enemigoIdx);
+                  console.log('Estado actual:', JSON.stringify(this.data.enemigosDerrotados));
+                }
+              } else if (tipo === 'monstruo') {
+                if (!this.data.enemigosDerrotados.monstruos.some(e => e.isla === islaIdx)) {
+                  this.data.enemigosDerrotados.monstruos.push({isla: islaIdx});
+                  console.log('Monstruo derrotado y registrado:', islaIdx);
+                  console.log('Estado actual:', JSON.stringify(this.data.enemigosDerrotados));
+                }
+              } else if (tipo === 'jefe') {
+                // lógica existente para el jefe final (cambiarIsla, etc.)
+                setTimeout(() => {
+                  const overlay = document.createElement('div');
+                  overlay.id = 'congrats-overlay';
+                  overlay.innerHTML = `<div class="message">¡Felicidades! Lo has logrado!</div>`;
+                  document.body.appendChild(overlay);
+                  overlay.addEventListener('click', () => overlay.remove());
+                }, 500);
               }
-            } else if (tipo === 'monstruo') {
-              if (!this.data.enemigosDerrotados.monstruos.some(e => e.isla === islaIdx)) {
-                this.data.enemigosDerrotados.monstruos.push({isla: islaIdx});
-                console.log('Monstruo derrotado y registrado:', islaIdx);
-                console.log('Estado actual:', JSON.stringify(this.data.enemigosDerrotados));
-              }
-            }
             this.combat3d.hide();
           } else {
             this.hud.showMessage('Has perdido el combate. Recupérate y vuelve a intentarlo.');

--- a/src/overworld.js
+++ b/src/overworld.js
@@ -14,10 +14,16 @@ export class OverworldMap {
     this.moviendo = false;
     this.direccion = 1; // 1 derecha, -1 izquierda
     this.animacion = null;
-    
+
+    // contenedor del overworld y configuración inicial de estilos
+    this.container = document.getElementById('overworld');
+    if (this.container) {
+      this.container.classList.add('overworld-container');
+    }
+
     // Nueva propiedad para controlar qué isla se está mostrando actualmente
     this.islaActual = 0;
-    
+
     window.addEventListener('keydown', e => this.handleKey(e));
   }
   
@@ -47,12 +53,24 @@ export class OverworldMap {
   }
   
   draw() {
+    // 1) Medir ancho y calcular paso entre nodos
+    const width = this.container ? this.container.clientWidth : 0;
+    const count = this.nodos.length;
+    const padding = 40;
+    const usable = width - padding * 2;
+    const step = count > 1 ? usable / (count - 1) : 0;
+
+    // 2) Reasignar x de cada nodo
+    this.nodos.forEach((nodo, i) => {
+      nodo.x = padding + step * i;
+    });
+
     // Obtener nodos filtrados para la isla actual
     const nodosVisibles = this.getNodosIslaActual();
-    
+
     // Limpiar cualquier contenido previo del SVG
-    document.getElementById('overworld').innerHTML = '';
-    
+    this.container.innerHTML = '';
+
     console.log(`Dibujando isla ${this.islaActual} con ${nodosVisibles.length} nodos visibles`);
     
     // SVG fondo tipo Mario World
@@ -319,7 +337,7 @@ export class OverworldMap {
       // No dibujar el ícono final directamente si ya se dibujó
       if (nodo.tipo !== 'fin') {
         svg.push(`
-          <g class='map-nodo${idxOriginal === this.nodoActual ? ' selected' : ''}' 
+          <g class='map-nodo node${idxOriginal === this.nodoActual ? ' selected' : ''}'
              data-idx='${idxOriginal}' 
              transform='translate(${pos.x-30},${pos.y-40}) scale(${escala})' 
              style='filter: ${filtro}; opacity: ${esAccesible ? 0.9 : 1}'>
@@ -344,7 +362,7 @@ export class OverworldMap {
     }
     
     svg.push('</svg>');
-    document.getElementById('overworld').innerHTML = svg.join('');
+    this.container.innerHTML = svg.join('');
     
     // Añade animación al personaje
     if (nodoActualVisible) {
@@ -430,7 +448,7 @@ export class OverworldMap {
       }
       
       // FORZAR un reinicio completo del mapa
-      document.getElementById('overworld').innerHTML = '';
+      this.container.innerHTML = '';
       
       // Redibujar el mapa con la nueva isla y nodos correctos
       this.draw();
@@ -534,7 +552,7 @@ export class OverworldMap {
         particula.style.top = `${alturaCurva}px`;
         particula.style.zIndex = '1000';
         particula.style.opacity = '0.8';
-        document.getElementById('overworld').appendChild(particula);
+        this.container.appendChild(particula);
         
         // Animar y eliminar partícula
         setTimeout(() => {

--- a/styles/ui.css
+++ b/styles/ui.css
@@ -18,4 +18,38 @@
 @keyframes fadeIn { from { opacity:0; } to { opacity:1; } }
 @keyframes parchmentIn { from { transform: scale(0.8); opacity:0; } to { transform: scale(1); opacity:1; } }
 #inventario, #tienda, #tutorial { background: #e3f3fc; border-radius: 18px; box-shadow: 0 4px 16px #b2f0c2aa; padding: 24px 18px 18px 18px; margin: 0 auto 18px auto; max-width: 600px; position: relative; display: none; }
-#dialogo { padding: 16px; background: #e3f3fc; border-radius: 14px; margin-bottom: 12px; min-height: 60px; font-size: 1.1em; box-shadow: 0 2px 8px #b2f0c2aa; display: flex; align-items: center; } 
+#dialogo { padding: 16px; background: #e3f3fc; border-radius: 14px; margin-bottom: 12px; min-height: 60px; font-size: 1.1em; box-shadow: 0 2px 8px #b2f0c2aa; display: flex; align-items: center; }
+/* estilos responsivos para el overworld y overlay de victoria */
+.overworld-container {
+  width: 100%;
+  overflow-x: auto;
+  padding: 1rem 0;
+  box-sizing: border-box;
+}
+.overworld-container svg {
+  width: 100%;
+  height: auto;
+  max-height: 60vh;
+}
+.node {
+  transition: transform 0.3s;
+}
+#congrats-overlay {
+  position: fixed;
+  top: 0; left: 0;
+  width: 100%; height: 100%;
+  background: rgba(0, 0, 0, 0.75);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+}
+#congrats-overlay .message {
+  background: #fff;
+  padding: 2rem 3rem;
+  border-radius: 12px;
+  font-size: 2rem;
+  font-weight: bold;
+  color: #2a7f62;
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- style overworld container and add celebratory overlay styles
- distribute overworld nodes based on container width
- display congratulatory overlay after defeating final boss

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d6be941fc832db6e58bab76920cf4