### PR TITLE
feat: add custom trinomio monster exercises

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -188,7 +188,18 @@ export class GameData {
         {x:445, y:260, tipo:'minion', isla:1, idx:1},
         {x:520, y:320, tipo:'cofre', isla:1, chestID:'chest9', parchment:2},
         {x:595, y:260, tipo:'minion', isla:1, idx:2},
-        {x:670, y:320, tipo:'monstruo', isla:1},
+        {
+          x:670,
+          y:320,
+          tipo:'monstruo',
+          isla:1,
+          subtema:'Trinomio general ax² + bx + c',
+          ejercicios:[
+            {pregunta:'¿Factoriza: 2x^2 + 5x + 3?', respuesta:'(2x+3)(x+1)'},
+            {pregunta:'¿Factoriza: 3x^2 + 10x + 7?', respuesta:'(3x+7)(x+1)'},
+            {pregunta:'¿Factoriza: 4a^2 + 11a + 6?', respuesta:'(4a+3)(a+2)'}
+          ]
+        },
       ];
     
     // Rutas alternativas o atajos (para expansión futura)

--- a/src/game.js
+++ b/src/game.js
@@ -31,13 +31,13 @@ export class Game {
   }
   
   // Llamado por OverworldMap cuando se entra a un nodo de combate
-  startCombat3D(tipo, islaIdx, enemigoIdx) {
+  startCombat3D(tipo, islaIdx, enemigoIdx, ejerciciosOverride) {
     const isla = this.data.islas[islaIdx];
     let enemigo;
     if (tipo === 'minion') enemigo = isla.enemigos[enemigoIdx];
     else enemigo = isla.monstruo;
 
-    const ejercicios = enemigo.ejercicios || [{pregunta: enemigo.pregunta, respuesta: enemigo.respuesta}];
+    const ejercicios = ejerciciosOverride || enemigo.ejercicios || [{pregunta: enemigo.pregunta, respuesta: enemigo.respuesta}];
     let idxActual = 0;
     let hpActual = enemigo.salud;
     const hpMax = enemigo.salud;

--- a/src/overworld.js
+++ b/src/overworld.js
@@ -650,12 +650,12 @@ export class OverworldMap {
         }
       } else {
         // Obtener nombre del monstruo para personalizar el mensaje
-        const nombreMonstruo = this.data.islas[nodo.isla]?.monstruo?.nombre || "Jefe";
-        this.hud.showMessage(`¡Cuidado! ¡${nombreMonstruo} te desafía!`);
-        setTimeout(() => this.game.startCombat3D('monstruo', nodo.isla), 1000);
+          const nombreMonstruo = this.data.islas[nodo.isla]?.monstruo?.nombre || "Jefe";
+          this.hud.showMessage(`¡Cuidado! ¡${nombreMonstruo} te desafía!`);
+          setTimeout(() => this.game.startCombat3D('monstruo', nodo.isla, null, nodo.ejercicios), 1000);
+        }
       }
-    }
-    else if(nodo.tipo === 'profesor') {
+      else if(nodo.tipo === 'profesor') {
       // Mostrar tutorial temático según la isla
       const temaIsla = this.data.islas[nodo.isla]?.tema || "factorización";
       const nombreIsla = this.data.islas[nodo.isla]?.nombre || "esta isla";


### PR DESCRIPTION
## Summary
- provide explicit exercises for the Trinomio general ax²+bx+c boss node
- allow overworld to forward custom exercises to combat
- enable combat system to accept overridden exercise sets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689169ab97f0832db45f3cb6e0376114