### PR TITLE
Unify Factorilandia island and add final victory screen

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -91,6 +91,18 @@ export class GameData {
             ],
             pregunta: "¿Factoriza: x^2 - 16?",
             respuesta: "(x+4)(x-4)"
+          },
+          {
+            nombre: "Monstruo ax²+bx+c",
+            salud: 100,
+            color: "#f06292",
+            ejercicios: [
+              {pregunta: "¿Factoriza: 2x^2 + 5x + 3?", respuesta: "(2x+3)(x+1)"},
+              {pregunta: "¿Factoriza: 3x^2 + 10x + 7?", respuesta: "(3x+7)(x+1)"},
+              {pregunta: "¿Factoriza: 4a^2 + 11a + 6?", respuesta: "(4a+3)(a+2)"}
+            ],
+            pregunta: "¿Factoriza: 2x^2 + 5x + 3?",
+            respuesta: "(2x+3)(x+1)"
           }
         ],
         monstruo: {
@@ -104,64 +116,9 @@ export class GameData {
           ],
           pregunta: "¿Factoriza: 8m^2 - 12m?",
           respuesta: "4m(2m-3)"
-        }
-      },
-      {
-        nombre: "Trinomio ax²+bx+c",
-        tema: "Trinomios generales",
-        color: "#F0A0D8",
-        descripcion: "En esta isla aprenderás a factorizar trinomios con coeficiente principal distinto de 1.",
-        enemigos: [
-          {
-            nombre: "Bandido Ax²",
-            salud: 70,
-            color: "#ab47bc",
-            ejercicios: [
-              {pregunta: "¿Factoriza: 2x^2 + 5x + 3?", respuesta: "(2x+3)(x+1)"},
-              {pregunta: "¿Factoriza: 3x^2 + 10x + 7?", respuesta: "(3x+7)(x+1)"},
-              {pregunta: "¿Factoriza: 4a^2 + 11a + 6?", respuesta: "(4a+3)(a+2)"}
-            ],
-            pregunta: "¿Factoriza: 2x^2 + 5x + 3?",
-            respuesta: "(2x+3)(x+1)"
-          },
-          {
-            nombre: "Asaltante Bx",
-            salud: 80,
-            color: "#ff7043",
-            ejercicios: [
-              {pregunta: "¿Factoriza: 5x^2 + 13x + 6?", respuesta: "(5x+3)(x+2)"},
-              {pregunta: "¿Factoriza: 6m^2 + 7m - 3?", respuesta: "(3m-1)(2m+3)"},
-              {pregunta: "¿Factoriza: 3y^2 - 4y - 4?", respuesta: "(3y+2)(y-2)"}
-            ],
-            pregunta: "¿Factoriza: 5x^2 + 13x + 6?",
-            respuesta: "(5x+3)(x+2)"
-          },
-          {
-            nombre: "Cazador C",
-            salud: 85,
-            color: "#26a69a",
-            ejercicios: [
-              {pregunta: "¿Factoriza: 4x^2 - x - 5?", respuesta: "(4x+5)(x-1)"},
-              {pregunta: "¿Factoriza: 7x^2 + 2x - 3?", respuesta: "(7x-3)(x+1)"},
-              {pregunta: "¿Factoriza: 3a^2 - a - 4?", respuesta: "(3a+4)(a-1)"}
-            ],
-            pregunta: "¿Factoriza: 4x^2 - x - 5?",
-            respuesta: "(4x+5)(x-1)"
           }
-        ],
-        monstruo: {
-          nombre: "Señor ax²+bx+c",
-          salud: 130,
-          ejercicios: [
-            {pregunta: "¿Factoriza: 6x^2 + x - 2?", respuesta: "(3x+2)(2x-1)"},
-            {pregunta: "¿Factoriza: 8a^2 + 14a + 3?", respuesta: "(4a+1)(2a+3)"},
-            {pregunta: "¿Factoriza: 9m^2 - 6m - 8?", respuesta: "(3m+2)(3m-4)"}
-          ],
-          pregunta: "¿Factoriza: 6x^2 + x - 2?",
-          respuesta: "(3x+2)(2x-1)"
         }
-      }
-    ];
+      ];
     
     // Mapa estilo laberinto con nodos en una trayectoria más clara y organizada
       this.mapNodos = [
@@ -179,27 +136,8 @@ export class GameData {
         {x:895, y:260, tipo:'minion', isla:0, idx:4},
         {x:970, y:320, tipo:'cofre', isla:0, chestID:'chest6', parchment:5},
         {x:1045, y:260, tipo:'minion', isla:0, idx:5},
-        {x:1120, y:320, tipo:'monstruo', isla:0},
-        // Isla 1: Trinomio ax²+bx+c
-        {x:145, y:260, tipo:'profesor', isla:1},
-        {x:220, y:320, tipo:'cofre', isla:1, chestID:'chest7', parchment:0},
-        {x:295, y:260, tipo:'minion', isla:1, idx:0},
-        {x:370, y:320, tipo:'cofre', isla:1, chestID:'chest8', parchment:1},
-        {x:445, y:260, tipo:'minion', isla:1, idx:1},
-        {x:520, y:320, tipo:'cofre', isla:1, chestID:'chest9', parchment:2},
-        {x:595, y:260, tipo:'minion', isla:1, idx:2},
-        {
-          x:670,
-          y:320,
-          tipo:'monstruo',
-          isla:1,
-          subtema:'Trinomio general ax² + bx + c',
-          ejercicios:[
-            {pregunta:'¿Factoriza: 2x^2 + 5x + 3?', respuesta:'(2x+3)(x+1)'},
-            {pregunta:'¿Factoriza: 3x^2 + 10x + 7?', respuesta:'(3x+7)(x+1)'},
-            {pregunta:'¿Factoriza: 4a^2 + 11a + 6?', respuesta:'(4a+3)(a+2)'}
-          ]
-        },
+        {x:1120, y:260, tipo:'minion', isla:0, idx:6},
+        {x:1195, y:320, tipo:'monstruo', isla:0},
       ];
     
     // Rutas alternativas o atajos (para expansión futura)

--- a/src/overworld.js
+++ b/src/overworld.js
@@ -461,7 +461,12 @@ export class OverworldMap {
       
       console.log(`Cambio a isla ${nuevaIsla} completado`);
     } else if (nuevaIsla >= this.data.islas.length && this.data.esIslaCompletada(this.islaActual)) {
-      this.hud.showMessage('¡Lo lograste! Felicidades por completar Factorilandia.');
+      this.hud.showMessage('¡Felicidades, lo lograste!');
+      const overlay = document.createElement('div');
+      overlay.id = 'congrats-overlay';
+      overlay.innerHTML = '<div class="message">¡Felicidades, lo lograste!</div>';
+      document.body.appendChild(overlay);
+      document.getElementById('overworld').style.display = 'none';
     }
   }
   

--- a/tests/isla.test.js
+++ b/tests/isla.test.js
@@ -2,22 +2,21 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import { GameData } from '../src/data.js';
 
-test('GameData incluye isla ax²+bx+c', () => {
+test('GameData tiene una sola isla', () => {
   const data = new GameData();
-  const isla = data.islas.find(i => i.nombre.includes('ax²+bx+c'));
-  assert.ok(isla, 'Debe existir la isla ax²+bx+c');
-  assert.equal(isla.enemigos.length, 3);
+  assert.equal(data.islas.length, 1);
 });
 
-test('GameData incluye isla Factorilandia con 6 enemigos', () => {
+test('Factorilandia incluye enemigo ax²+bx+c', () => {
   const data = new GameData();
-  const isla = data.islas.find(i => i.nombre === 'Factorilandia');
-  assert.ok(isla, 'Debe existir la isla Factorilandia');
-  assert.equal(isla.enemigos.length, 6);
+  const isla = data.islas[0];
+  const enemigo = isla.enemigos.find(e => e.nombre.includes('ax²+bx+c'));
+  assert.ok(enemigo, 'Debe existir enemigo ax²+bx+c en Factorilandia');
+  assert.equal(isla.enemigos.length, 7);
 });
 
-test('mapNodos contiene nodos para la nueva isla', () => {
+test('mapNodos no contiene otras islas', () => {
   const data = new GameData();
   const nodos = data.mapNodos.filter(n => n.isla === 1);
-  assert.ok(nodos.length > 0, 'Deben existir nodos para la isla 1');
+  assert.equal(nodos.length, 0);
 });


### PR DESCRIPTION
## Summary
- Fold Trinomio ax²+bx+c into Factorilandia as a new enemy and remove extra island
- Extend map path to include the new encounter and show a final congratulations overlay after the last boss
- Update tests to reflect the single-island structure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68994737eca8832d8ad1f8cb4e6c4971