### PR TITLE
Add final knowledge chest and resize minions

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -136,8 +136,9 @@ export class GameData {
         {x:895, y:260, tipo:'minion', isla:0, idx:4},
         {x:970, y:320, tipo:'cofre', isla:0, chestID:'chest6', parchment:5},
         {x:1045, y:260, tipo:'minion', isla:0, idx:5},
-        {x:1120, y:260, tipo:'minion', isla:0, idx:6},
-        {x:1195, y:320, tipo:'monstruo', isla:0},
+        {x:1120, y:320, tipo:'cofre', isla:0, chestID:'chest7', parchment:6},
+        {x:1195, y:260, tipo:'minion', isla:0, idx:6},
+        {x:1270, y:320, tipo:'monstruo', isla:0},
       ];
     
     // Rutas alternativas o atajos (para expansión futura)
@@ -174,6 +175,10 @@ export class GameData {
       {
         titulo: "Diferencia de cuadrados",
         contenido: "Forma: a² - b² = (a + b)(a - b). Ejemplo: x² - 16 = (x + 4)(x - 4)"
+      },
+      {
+        titulo: "Sumas y diferencias de cubos",
+        contenido: "Forma: a³ ± b³ = (a ± b)(a² ∓ ab + b²). Ejemplo: x³ + 8 = (x + 2)(x² - 2x + 4)"
       }
     ];
   }

--- a/src/overworld.js
+++ b/src/overworld.js
@@ -213,13 +213,13 @@ export class OverworldMap {
           
           // Minions con colores específicos por isla
           icon = `
-            <g transform='translate(-30,-30)'>
-              <circle cx='60' cy='60' r='40' fill='${color}' stroke='#e65100' stroke-width='4'/>
-              <ellipse cx='50' cy='55' rx='8' ry='12' fill='#fff'/>
-              <ellipse cx='70' cy='55' rx='8' ry='12' fill='#fff'/>
-              <ellipse cx='50' cy='55' rx='3' ry='5' fill='#000'/>
-              <ellipse cx='70' cy='55' rx='3' ry='5' fill='#000'/>
-              <ellipse cx='60' cy='75' rx='12' ry='5' fill='#a67c00'/>
+            <g transform='translate(-25,-25)'>
+              <circle cx='50' cy='50' r='30' fill='${color}' stroke='#e65100' stroke-width='4'/>
+              <ellipse cx='40' cy='45' rx='6' ry='9' fill='#fff'/>
+              <ellipse cx='60' cy='45' rx='6' ry='9' fill='#fff'/>
+              <ellipse cx='40' cy='45' rx='2' ry='4' fill='#000'/>
+              <ellipse cx='60' cy='45' rx='2' ry='4' fill='#000'/>
+              <ellipse cx='50' cy='62' rx='9' ry='4' fill='#a67c00'/>
             </g>`;
         } else {
           // Nodo vacío con marca de derrotado 


### PR DESCRIPTION
## Summary
- Add missing knowledge chest and parchment about cubics before final ax²+bx+c minion.
- Shrink minion overworld sprites for better spacing.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68995818b51c832d97439ce710e7830b